### PR TITLE
Capital gains tax brackets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     'tomli; python_version < "3.11"',
-    'scipy'
+    'scipy >= 1.9.2'
 ]
 
 [project.scripts]


### PR DESCRIPTION
The computation of capital gains taxes required the addition of integrality constraints and some additional constraints to force positive values and compute min() functions.  It's kind of a mess.  Depending on the values in your config file this can greatly slow down the computation of your answer.  A timeout has been added so that it gives you the closest result after 10 minutes.

This requires at least version 1.9.2 of scipy.